### PR TITLE
resolver: skip restart if disabled.

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -275,6 +275,10 @@ pub fn stop(ctx: &Context) -> Result<()> {
 }
 
 pub fn restart(ctx: &Context) -> Result<()> {
+    let config = &ctx.config.resolver;
+    if !config.enabled() {
+        return Ok(());
+    }
     step("Restarting 'kaspa-resolver'", || {
         systemd::restart(&ctx.config.resolver)
     })


### PR DESCRIPTION
While resolver service disabled, on "restart all services" it try and fail

```
◐  Restarting 'kaspa-resolver'                                                                                                                                                                        

Failed to restart kaspa-resolver.service: Unit kaspa-resolver.service not found.

▲  command ["sudo", "-kS", "-p", "", "systemctl", "restart", "kaspa-resolver"] exited with code 5
│
■  command ["sudo", "-kS", "-p", "", "systemctl", "restart", "kaspa-resolver"] exited with code 5
│  
■  Io(Custom { kind: Other, error: "command [\"sudo\", \"-kS\", \"-p\", \"\", \"systemctl\", \"restart\", \"kaspa-resolver\"] exited with code 5" })

```