### PR TITLE
chore: pnnv1 toccata for tn12 and tn10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.68",
+ "syn 2.0.87",
  "which",
 ]
 
@@ -457,7 +457,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
  "syn_derive",
 ]
 
@@ -643,7 +643,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1056,7 +1056,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1484,6 +1484,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pemfile",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -1781,7 +1782,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1850,7 +1851,7 @@ checksum = "70df726c43c645ef1dde24c7ae14692036ebe5457c92c5f0ec4cfceb99634ff6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1893,7 +1894,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1992,7 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2370,11 +2371,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2385,10 +2387,11 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -2404,14 +2407,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.203"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2545,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2563,7 +2575,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2669,7 +2681,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2745,7 +2757,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3055,7 +3067,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -3089,7 +3101,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3512,7 +3524,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3532,5 +3544,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.87",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "khost"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "addr",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ tokio = { version = "1.38.0", default-features = false, features = ['io-util','t
 toml = "0.8.14"
 whoami = "1.5.1"
 xxhash-rust = { version = "0.8.7", features = ["xxh3"] }
+semver = "1.0.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khost"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Kaspa developers"]
 license = "MIT OR Apache-2.0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+dockerfile = "./cross/x86_64-unknown-linux-gnu.Dockerfile"

--- a/cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,8 +1,8 @@
-ARG CROSS_BASE_IMAGE
-FROM $CROSS_BASE_IMAGE
+FROM rust:1-bookworm
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        build-essential \
         pkg-config \
         libssl-dev \
         ca-certificates && \

--- a/cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,0 +1,9 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,7 +119,7 @@ impl Config {
                         *kaspad_config.origin_mut() = Self::pnnv1_toccata_origin()?;
                         update = true;
 
-                        log::warning("warning: a manual tn10 node DB reset will be needed, either\n\t- remove manually, default location: `~/.rusty-kaspa/kaspa-testnet-10`\t- or, uninstall tn10 and re-install");
+                        let _ = log::warning("warning: a manual tn10 node DB reset will be needed, either\n\t- remove manually, default location: `~/.rusty-kaspa/kaspa-testnet-10`\t- or, uninstall tn10 and re-install");
                     }
                     _ => (),
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,8 @@ impl Config {
                     Network::Supported(SupportedNetwork::Testnet10) => {
                         *kaspad_config.origin_mut() = Self::pnnv1_toccata_origin()?;
                         update = true;
+
+                        log::warning("warning: a manual tn10 node DB reset will be needed, either\n\t- remove manually, default location: `~/.rusty-kaspa/kaspa-testnet-10`\t- or, uninstall tn10 and re-install");
                     }
                     _ => (),
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ impl Config {
             .with_local_interface(8989);
 
         let pnnv1_origin = Self::pnnv1_origin()?;
-        let tn12_origin = Self::pnnv1tn12_origin()?;
+        let tn12_origin = Self::pnnv1_toccata_origin()?;
 
         let kaspad = SupportedNetwork::iter()
             .copied()
@@ -56,10 +56,10 @@ impl Config {
         Origin::try_new("https://github.com/aspectron/rusty-kaspa", Some("pnn-v1"))
     }
 
-    pub fn pnnv1tn12_origin() -> Result<Origin> {
+    pub fn pnnv1_toccata_origin() -> Result<Origin> {
         Origin::try_new(
             "https://github.com/aspectron/rusty-kaspa",
-            Some("pnn-v1-tn12"),
+            Some("pnn-v1-toccata"),
         )
     }
 }
@@ -97,22 +97,30 @@ impl Config {
                 .any(|config| config.network() == SupportedNetwork::Testnet12.into())
             {
                 config.kaspad.push(kaspad::Config::new(
-                    Self::pnnv1tn12_origin()?,
+                    Self::pnnv1_toccata_origin()?,
                     SupportedNetwork::Testnet12.into(),
                 ));
                 update = true;
             }
 
             // update rk origin
-            for kaspad_config in config.kaspad.iter_mut().filter(|kaspad_config| {
-                kaspad_config.is_supported_network()
-                    && matches!(
-                        kaspad_config.network(),
-                        Network::Supported(SupportedNetwork::Testnet10 | SupportedNetwork::Mainnet)
-                    )
-            }) {
-                *kaspad_config.origin_mut() = Self::pnnv1_origin()?;
-                update = true;
+            for kaspad_config in config
+                .kaspad
+                .iter_mut()
+                .filter(|kaspad_config| kaspad_config.is_supported_network())
+            {
+                match kaspad_config.network() {
+                    Network::Supported(SupportedNetwork::Mainnet) => {
+                        *kaspad_config.origin_mut() = Self::pnnv1_origin()?;
+                        update = true;
+                    }
+                    // set to toccata in the meantime of master release
+                    Network::Supported(SupportedNetwork::Testnet10) => {
+                        *kaspad_config.origin_mut() = Self::pnnv1_toccata_origin()?;
+                        update = true;
+                    }
+                    _ => (),
+                }
             }
         }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -180,14 +180,18 @@ where
     enum Preset {
         PNNv1,
         // Delta,
-        Tn12,
+        PNNv1Toccata,
         Custom,
     }
 
     let preset = if name == "rusty-kaspa" {
         cliclack::select(format!("Select git origin for '{name}':"))
             .item(Preset::PNNv1, "pnn-v1 (aspectron/pnn-v1)", "")
-            .item(Preset::Tn12, "tn12 (kaspanet/tn12)", "")
+            .item(
+                Preset::PNNv1Toccata,
+                "pnn-v1-toccata (aspectron/pnn-v1-toccata)",
+                "",
+            )
             // .item(
             //     Preset::Delta,
             //     "Delta",
@@ -201,7 +205,7 @@ where
 
     let origin = match preset {
         Preset::PNNv1 => Config::pnnv1_origin()?,
-        Preset::Tn12 => Config::pnnv1tn12_origin()?,
+        Preset::PNNv1Toccata => Config::pnnv1_toccata_origin()?,
         // Preset::Delta => {
         //     Origin::try_new("https://github.com/aspectron/rusty-kaspa", Some("delta"))?
         // }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -2,6 +2,7 @@ pub use cfg_if::cfg_if;
 pub use cliclack::log;
 pub use is_root::is_root;
 pub use pad::{Alignment, PadStr};
+pub use semver::Version;
 pub use serde::{Deserialize, Serialize};
 pub use sha2::{Digest, Sha256};
 pub use std::collections::{HashMap, HashSet, VecDeque};

--- a/src/kaspad.rs
+++ b/src/kaspad.rs
@@ -260,12 +260,10 @@ pub fn has_legacy_network(ctx: &Context) -> bool {
         || legacy_network_service_exists()
 }
 
-pub fn warn_legacy_network(ctx: &Context) -> Result<()> {
+pub fn warn_legacy_network(ctx: &Context) -> () {
     if has_legacy_network(ctx) {
-        log::warning("testnet-11 is deprecated and no longer supported for new kHOST deployments. If kaspa-testnet-11 is installed or running, uninstall it and install/enable testnet-12 instead. testnet-11 compatibility is kept only to load legacy configs and will be removed in a future version.")?;
+        let _ = log::warning("testnet-11 is deprecated and no longer supported for new kHOST deployments. If kaspa-testnet-11 is installed or running, uninstall it and install/enable testnet-12 instead. testnet-11 compatibility is kept only to load legacy configs and will be removed in a future version.");
     }
-
-    Ok(())
 }
 
 pub fn fetch(ctx: &Context) -> Result<()> {

--- a/src/kaspad.rs
+++ b/src/kaspad.rs
@@ -339,7 +339,7 @@ pub fn uninstall(ctx: &Context) -> Result<()> {
             let data_folder = if let Some(data_folder) = &config.data_folder {
                 data_folder.clone()
             } else {
-                home_folder().join(".kaspad")
+                home_folder().join(".rusty-kaspa")
             };
 
             let network_folder = data_folder.join(config.network.to_string());

--- a/src/kaspad.rs
+++ b/src/kaspad.rs
@@ -260,7 +260,7 @@ pub fn has_legacy_network(ctx: &Context) -> bool {
         || legacy_network_service_exists()
 }
 
-pub fn warn_legacy_network(ctx: &Context) -> () {
+pub fn warn_legacy_network(ctx: &Context) {
     if has_legacy_network(ctx) {
         let _ = log::warning("testnet-11 is deprecated and no longer supported for new kHOST deployments. If kaspa-testnet-11 is installed or running, uninstall it and install/enable testnet-12 instead. testnet-11 compatibility is kept only to load legacy configs and will be removed in a future version.");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,8 @@ fn main() {
 
     sudo::init(&mut ctx);
 
-    kaspad::warn_legacy_network(&ctx).ok();
+    kaspad::warn_legacy_network(&ctx);
+    nginx::warn_cve_2026_42945();
 
     let first_run = !ctx.config.bootstrap;
 

--- a/src/nginx.rs
+++ b/src/nginx.rs
@@ -278,11 +278,15 @@ impl Display for NginxConfig {
     }
 }
 
-pub fn version() -> Option<String> {
-    cmd!("nginx", "-v")
-        .read()
-        .ok()
-        .map(|s| s.trim().to_string())
+pub fn version() -> Option<Version> {
+    let raw = cmd!("nginx", "-v").read().ok()?;
+
+    let version = raw
+        .trim()
+        .strip_prefix("nginx version: nginx/")
+        .unwrap_or(raw.trim());
+
+    Version::parse(version).ok()
 }
 
 pub fn install(_ctx: &Context) -> Result<()> {
@@ -331,4 +335,20 @@ pub fn reconfigure(ctx: &Context) -> Result<()> {
         store(NginxConfig::new(server_kind, proxy_configs))?;
         reload()
     })
+}
+
+pub fn warn_cve_2026_42945() {
+    let Some(installed_version) = version() else {
+        let _ = log::warning("warning: could not determine nginx version");
+        return;
+    };
+
+    let fixed_stable = Version::parse("1.30.1").unwrap();
+    let fixed_mainline = Version::parse("1.31.0").unwrap();
+
+    let is_fixed = installed_version >= fixed_mainline || installed_version >= fixed_stable;
+
+    if !is_fixed {
+        log::warning(format!("warning: nginx {} may be vulnerable to CVE-2026-42945; upgrade to >= 1.30.1 or >= 1.31.0", installed_version)).expect("should log warning");
+    }
 }


### PR DESCRIPTION
* edit preset tn12 to aspectron/toccata
* unify tn10 and tn12 to use toccata
* nginx notify cve
* cross build files
* use `.rusty-kaspa` instead of old `.kaspad` for node data dir while using "delete node data" command